### PR TITLE
Auto-generate DNS overrides from Ansible inventory

### DIFF
--- a/group_vars/piholes.yaml
+++ b/group_vars/piholes.yaml
@@ -1,15 +1,9 @@
 dnsmasq_config_dir: /etc/dnsmasq.d
-# TODO: Generate these from the inventory.
-dns_overrides:
+
+# Extra DNS entries for devices not in the Ansible inventory.
+# Managed hosts (proxmox_vms, proxmox_hosts, piholes, unmanaged groups) are
+# auto-generated from inventory/hosts.yaml via the dns-overrides.conf.j2 template.
+dns_extra:
   - { ip: 192.168.42.238, custom_dns: "main.knxcloud.io" }
-  - { ip: 192.168.1.202, custom_dns: "pihole-primary.knxcloud.io" }
-  - { ip: 192.168.3.254, custom_dns: "pihole-backup.knxcloud.io" }
-  - { ip: 192.168.42.166, custom_dns: "ts.knxcloud.io" }
-  - { ip: 192.168.42.57, custom_dns: "pve1.knxcloud.io" }
-  - { ip: 192.168.42.239, custom_dns: "pve2.knxcloud.io" }
   - { ip: 192.168.1.217, custom_dns: "nas.knxcloud.io" }
   - { ip: 192.168.92.60, custom_dns: "dinos.sh" }
-  - { ip: 192.168.60.44, custom_dns: "mon.knxcloud.io" }
-  - { ip: 192.168.60.45, custom_dns: "infra.knxcloud.io" }
-  - { ip: 192.168.42.122, custom_dns: "mqtt.knxcloud.io" }
-  - { ip: 192.168.60.46, custom_dns: "apps.knxcloud.io" }

--- a/roles/pihole/templates/dns-overrides.conf.j2
+++ b/roles/pihole/templates/dns-overrides.conf.j2
@@ -1,4 +1,14 @@
 # {{ ansible_managed }}
-{% for override in dns_overrides %}
-address=/{{ override.custom_dns }}/{{ override.ip }}
+
+# Auto-generated from inventory
+{% set auto_groups = ['proxmox_vms', 'proxmox_hosts', 'piholes', 'unmanaged'] %}
+{% for group in auto_groups %}
+{% for host in groups[group] | default([]) %}
+address=/{{ host }}.{{ hostname_root }}/{{ hostvars[host]['ansible_host'] }}
+{% endfor %}
+{% endfor %}
+
+# Extra static entries (devices not in inventory)
+{% for entry in dns_extra | default([]) %}
+address=/{{ entry.custom_dns }}/{{ entry.ip }}
 {% endfor %}


### PR DESCRIPTION
## Summary
Refactored DNS override configuration to automatically generate entries from the Ansible inventory instead of maintaining a static list. This reduces duplication and ensures DNS records stay in sync with managed hosts.

## Key Changes
- Renamed `dns_overrides` variable to `dns_extra` to clarify its purpose
- Updated `dns-overrides.conf.j2` template to auto-generate DNS entries for hosts in managed groups (`proxmox_vms`, `proxmox_hosts`, `piholes`, `unmanaged`)
- Removed 9 static DNS entries that are now auto-generated from inventory (pihole instances, Proxmox hosts, monitoring/infrastructure services, MQTT broker)
- Retained 3 static entries in `dns_extra` for devices not tracked in the Ansible inventory (main.knxcloud.io, nas.knxcloud.io, dinos.sh)
- Added documentation comments explaining the separation between auto-generated and static entries

## Implementation Details
- The template now iterates through configured inventory groups and generates `address=` records using the hostname and `ansible_host` variable
- Uses `hostname_root` variable to construct fully qualified domain names
- Maintains backward compatibility with the `dns_extra` list for manual overrides
- Reduces maintenance burden by eliminating manual DNS record updates when hosts are added/removed from inventory

https://claude.ai/code/session_01Cgh7jQ3ti3ABWvAsfcLdHo